### PR TITLE
Fix modal-open class bug

### DIFF
--- a/src/modal.vue
+++ b/src/modal.vue
@@ -84,7 +84,7 @@
             }
         },
         beforeDestroy () {
-            document.body.className = document.body.className.replace(' modal-open', '');
+            document.body.className = document.body.className.replace(/\s?modal-open/, '');
         },
         watch: {
             show (value) {
@@ -99,7 +99,7 @@
                     }
 
                     window.setTimeout(() => {
-                        document.body.className = document.body.className.replace(' modal-open', '');
+                        document.body.className = document.body.className.replace(/\s?modal-open/, '');
                     }, this.duration || 0);
                 }
             }


### PR DESCRIPTION
space before 'modal-open' class could be deleted when modifying body's classes preventing the modal to remove the class when closed.
